### PR TITLE
Add FireSync plugin and Gemini triage integration

### DIFF
--- a/api/gemini.php
+++ b/api/gemini.php
@@ -1,0 +1,26 @@
+<?php
+require_once(dirname(__FILE__) . '/../include/gemini.php');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    exit;
+}
+
+$data = json_decode(file_get_contents('php://input'), true);
+$subject = $data['subject'] ?? '';
+$body    = $data['body'] ?? '';
+$prompt  = "You are a ticket triage assistant. Choose the best category and priority from the lists.\n".
+           "Categories: Incident: Software > VPN, Software > Email, Hardware > Printer, Hardware > Laptop, Network > Connectivity; " .
+           "Service Request: Software > Licensing, Hardware > New Employee, Access > Shared Drive, Access > New Account, Hardware > Peripheral Request.\n".
+           "Priorities: Low, Medium, High, Urgent.\n".
+           "Respond in JSON with keys category and priority.\n".
+           "Subject: $subject\nBody: $body";
+
+$response = GeminiClient::call($prompt);
+$choice = $response['candidates'][0]['content']['parts'][0]['text'] ?? '';
+$result = json_decode($choice, true);
+if (!is_array($result))
+    $result = array('category' => '', 'priority' => '');
+
+header('Content-Type: application/json');
+echo json_encode($result);

--- a/include/client/open.inc.php
+++ b/include/client/open.inc.php
@@ -115,6 +115,7 @@ if ($info['topicId'] && ($topic=Topic::lookup($info['topicId']))) {
   </table>
 <hr/>
   <p class="buttons" style="text-align:center;">
+        <input type="button" id="suggestFields" value="<?php echo __('Suggest Category/Priority'); ?>" onclick="suggestFields();">
         <input type="submit" value="<?php echo __('Create Ticket');?>">
         <input type="reset" name="reset" value="<?php echo __('Reset');?>">
         <input type="button" name="cancel" value="<?php echo __('Cancel'); ?>" onclick="javascript:
@@ -126,3 +127,27 @@ if ($info['topicId'] && ($topic=Topic::lookup($info['topicId']))) {
             window.location.href='index.php';">
   </p>
 </form>
+<script type="text/javascript">
+async function suggestFields() {
+    const subject = document.getElementById('subject') ? document.getElementById('subject').value : '';
+    const body = document.getElementById('message') ? document.getElementById('message').value : '';
+    try {
+        const res = await fetch('api/gemini.php', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({subject: subject, body: body})
+        });
+        const data = await res.json();
+        if (data.category) {
+            const cat = document.querySelector('select[name="category"]');
+            if (cat) cat.value = data.category;
+        }
+        if (data.priority) {
+            const pri = document.querySelector('select[name="priority"]');
+            if (pri) pri.value = data.priority;
+        }
+    } catch (e) {
+        console.log(e);
+    }
+}
+</script>

--- a/include/gemini.php
+++ b/include/gemini.php
@@ -1,0 +1,22 @@
+<?php
+class GeminiClient {
+    public static function call($prompt) {
+        $key = getenv('GEMINI_API_KEY');
+        if (!$key)
+            return null;
+        $url = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=' . $key;
+        $body = json_encode(array(
+            'contents' => array(array('parts' => array(array('text' => $prompt)))))
+        );
+        $ch = curl_init($url);
+        curl_setopt_array($ch, array(
+            CURLOPT_POST => true,
+            CURLOPT_HTTPHEADER => array('Content-Type: application/json'),
+            CURLOPT_POSTFIELDS => $body,
+            CURLOPT_RETURNTRANSFER => true
+        ));
+        $res = curl_exec($ch);
+        curl_close($ch);
+        return json_decode($res, true);
+    }
+}

--- a/include/plugins/firesync/config.php
+++ b/include/plugins/firesync/config.php
@@ -1,0 +1,17 @@
+<?php
+require_once(INCLUDE_DIR . 'class.plugin.php');
+
+class FireSyncPluginConfig extends PluginConfig {
+    function getOptions() {
+        return array(
+            'project_id' => new TextboxField(array(
+                'label' => 'Firebase Project ID',
+                'required' => true,
+            )),
+        );
+    }
+
+    function pre_save(&$config, &$errors) {
+        return true;
+    }
+}

--- a/include/plugins/firesync/plugin.php
+++ b/include/plugins/firesync/plugin.php
@@ -1,0 +1,62 @@
+<?php
+require_once(INCLUDE_DIR . 'class.plugin.php');
+
+class FireSyncPlugin extends Plugin {
+    var $config_class = 'FireSyncPluginConfig';
+
+    function bootstrap() {
+        Signal::connect('ticket.created', array($this, 'onTicketEvent'));
+        Signal::connect('threadentry.created', array($this, 'onThreadEntry'));
+    }
+
+    function onTicketEvent(Ticket $ticket) {
+        $payload = array(
+            'ticket_id' => $ticket->getId(),
+            'status'    => $ticket->getStatus(),
+            'created'   => $ticket->getCreateDate(),
+        );
+        $this->postToFirestore('tickets', $payload);
+    }
+
+    function onThreadEntry(ThreadEntry $entry) {
+        if ($entry->getThread()->getObjectType() != 'T')
+            return;
+        $payload = array(
+            'ticket_id' => $entry->getThreadId(),
+            'poster'    => $entry->getPoster(),
+            'message'   => $entry->getBody(),
+            'created'   => $entry->getCreateDate(),
+        );
+        $this->postToFirestore('tickets_comments', $payload);
+    }
+
+    private function postToFirestore($collection, array $payload) {
+        $project = $this->getConfig()->get('project_id');
+        $token = getenv('FIREBASE_TOKEN');
+        if (!$project || !$token)
+            return;
+
+        $url = sprintf('https://firestore.googleapis.com/v1/projects/%s/databases/(default)/documents/%s',
+            $project, $collection);
+        $body = json_encode(array('fields' => $this->buildFields($payload)));
+        $ch = curl_init($url);
+        curl_setopt_array($ch, array(
+            CURLOPT_POST => true,
+            CURLOPT_HTTPHEADER => array(
+                'Authorization: Bearer ' . $token,
+                'Content-Type: application/json'
+            ),
+            CURLOPT_POSTFIELDS => $body,
+            CURLOPT_RETURNTRANSFER => true
+        ));
+        curl_exec($ch);
+        curl_close($ch);
+    }
+
+    private function buildFields(array $data) {
+        $fields = array();
+        foreach ($data as $k => $v)
+            $fields[$k] = array('stringValue' => (string)$v);
+        return $fields;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce FireSync plugin to mirror ticket events and comments to Firestore
- add Gemini client and triage API endpoint
- enhance ticket creation form with smart category/priority suggestions

## Testing
- `php -l include/plugins/firesync/plugin.php`
- `php -l include/plugins/firesync/config.php`
- `php -l include/gemini.php`
- `php -l api/gemini.php`
- `php -l include/client/open.inc.php`


------
https://chatgpt.com/codex/tasks/task_e_689cafa938c48323bd0ff5319fc77541