### PR TITLE
Expand FireSync notifications and Gemini article drafting

### DIFF
--- a/api/gemini.php
+++ b/api/gemini.php
@@ -7,40 +7,51 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 }
 
 $data   = json_decode(file_get_contents('php://input'), true);
-$action = $data['action'] ?? 'triage';
+$action = $data['action'] ?? '';
 
 switch ($action) {
 case 'triage':
     $subject = $data['subject'] ?? '';
     $body    = $data['body'] ?? '';
-    $prompt  = "You are a ticket triage assistant. Choose the best category and priority from the lists.\n".
-               "Categories: Incident: Software > VPN, Software > Email, Hardware > Printer, Hardware > Laptop, Network > Connectivity; ".
-               "Service Request: Software > Licensing, Hardware > New Employee, Access > Shared Drive, Access > New Account, Hardware > Peripheral Request.\n".
-               "Priorities: Low, Medium, High, Urgent.\n".
-               "Respond in JSON with keys category and priority.\n".
-               "Subject: $subject\nBody: $body";
+    $prompt  = "You are a ticket triage assistant. Choose the best category and priority from the lists.\n"
+        . "Categories: Incident: Software > VPN, Software > Email, Hardware > Printer, Hardware > Laptop, Network > Connectivity; "
+        . "Service Request: Software > Licensing, Hardware > New Employee, Access > Shared Drive, Access > New Account, Hardware > Peripheral Request.\n"
+        . "Priorities: Low, Medium, High, Urgent.\n"
+        . "Respond in JSON with keys category and priority.\n"
+        . "Subject: $subject\nBody: $body";
 
     $response = GeminiClient::call($prompt);
+    if ($response === false || !is_array($response) || empty($response['candidates'])) {
+        error_log('Gemini API error: ' . json_encode($response));
+        http_response_code(502);
+        $result = array('category' => '', 'priority' => '');
+        break;
+    }
     $choice = $response['candidates'][0]['content']['parts'][0]['text'] ?? '';
     $result = json_decode($choice, true);
     if (!is_array($result))
         $result = array('category' => '', 'priority' => '');
-
-    header('Content-Type: application/json');
-    echo json_encode($result);
     break;
 
 case 'kb':
-    $topic   = $data['topic'] ?? '';
-    $content = $data['content'] ?? '';
-    $prompt  = "You are a technical writer. Draft or improve a knowledge base article.\n".
-               "Topic: $topic\nExisting Content:\n$content";
+    $question = $data['question'] ?? '';
+    $prompt = "You are a knowledge base assistant. Answer the user's question based on available information.\n"
+        . "Question: $question";
     $response = GeminiClient::call($prompt);
-    $text = $response['candidates'][0]['content']['parts'][0]['text'] ?? '';
-    header('Content-Type: application/json');
-    echo json_encode(array('article' => $text));
+    if ($response === false || !is_array($response) || empty($response['candidates'])) {
+        error_log('Gemini API error: ' . json_encode($response));
+        http_response_code(502);
+        $result = array('answer' => '');
+        break;
+    }
+    $answer = $response['candidates'][0]['content']['parts'][0]['text'] ?? '';
+    $result = array('answer' => $answer);
     break;
 
 default:
     http_response_code(400);
+    $result = array('error' => 'Unknown action');
 }
+
+header('Content-Type: application/json');
+echo json_encode($result);

--- a/api/gemini.php
+++ b/api/gemini.php
@@ -33,6 +33,24 @@ case 'triage':
         $result = array('category' => '', 'priority' => '');
     break;
 
+case 'summary':
+    $text   = $data['text'] ?? '';
+    $prompt = "You are a support assistant. Summarize the conversation and suggest troubleshooting steps.\n"
+        . "Respond in JSON with keys summary and steps (an array of strings).\n"
+        . $text;
+    $response = GeminiClient::call($prompt);
+    if ($response === false || !is_array($response) || empty($response['candidates'])) {
+        error_log('Gemini API error: ' . json_encode($response));
+        http_response_code(502);
+        $result = array('summary' => '', 'steps' => array());
+        break;
+    }
+    $choice = $response['candidates'][0]['content']['parts'][0]['text'] ?? '';
+    $result = json_decode($choice, true);
+    if (!is_array($result) || !isset($result['summary']) || !isset($result['steps']))
+        $result = array('summary' => '', 'steps' => array());
+    break;
+
 case 'kb':
     $question = $data['question'] ?? '';
     $prompt = "You are a knowledge base assistant. Answer the user's question based on available information.\n"

--- a/api/gemini.php
+++ b/api/gemini.php
@@ -1,0 +1,46 @@
+<?php
+require_once(dirname(__FILE__) . '/../include/gemini.php');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    exit;
+}
+
+$data   = json_decode(file_get_contents('php://input'), true);
+$action = $data['action'] ?? 'triage';
+
+switch ($action) {
+case 'triage':
+    $subject = $data['subject'] ?? '';
+    $body    = $data['body'] ?? '';
+    $prompt  = "You are a ticket triage assistant. Choose the best category and priority from the lists.\n".
+               "Categories: Incident: Software > VPN, Software > Email, Hardware > Printer, Hardware > Laptop, Network > Connectivity; ".
+               "Service Request: Software > Licensing, Hardware > New Employee, Access > Shared Drive, Access > New Account, Hardware > Peripheral Request.\n".
+               "Priorities: Low, Medium, High, Urgent.\n".
+               "Respond in JSON with keys category and priority.\n".
+               "Subject: $subject\nBody: $body";
+
+    $response = GeminiClient::call($prompt);
+    $choice = $response['candidates'][0]['content']['parts'][0]['text'] ?? '';
+    $result = json_decode($choice, true);
+    if (!is_array($result))
+        $result = array('category' => '', 'priority' => '');
+
+    header('Content-Type: application/json');
+    echo json_encode($result);
+    break;
+
+case 'kb':
+    $topic   = $data['topic'] ?? '';
+    $content = $data['content'] ?? '';
+    $prompt  = "You are a technical writer. Draft or improve a knowledge base article.\n".
+               "Topic: $topic\nExisting Content:\n$content";
+    $response = GeminiClient::call($prompt);
+    $text = $response['candidates'][0]['content']['parts'][0]['text'] ?? '';
+    header('Content-Type: application/json');
+    echo json_encode(array('article' => $text));
+    break;
+
+default:
+    http_response_code(400);
+}

--- a/include/client/open.inc.php
+++ b/include/client/open.inc.php
@@ -115,6 +115,7 @@ if ($info['topicId'] && ($topic=Topic::lookup($info['topicId']))) {
   </table>
 <hr/>
   <p class="buttons" style="text-align:center;">
+        <input type="button" id="suggestFields" value="<?php echo __('Suggest Category/Priority'); ?>" onclick="suggestFields();">
         <input type="submit" value="<?php echo __('Create Ticket');?>">
         <input type="reset" name="reset" value="<?php echo __('Reset');?>">
         <input type="button" name="cancel" value="<?php echo __('Cancel'); ?>" onclick="javascript:
@@ -126,3 +127,27 @@ if ($info['topicId'] && ($topic=Topic::lookup($info['topicId']))) {
             window.location.href='index.php';">
   </p>
 </form>
+<script type="text/javascript">
+async function suggestFields() {
+    const subject = document.getElementById('subject') ? document.getElementById('subject').value : '';
+    const body = document.getElementById('message') ? document.getElementById('message').value : '';
+    try {
+        const res = await fetch('api/gemini.php', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({action: 'triage', subject: subject, body: body})
+        });
+        const data = await res.json();
+        if (data.category) {
+            const cat = document.querySelector('select[name="category"]');
+            if (cat) cat.value = data.category;
+        }
+        if (data.priority) {
+            const pri = document.querySelector('select[name="priority"]');
+            if (pri) pri.value = data.priority;
+        }
+    } catch (e) {
+        console.log(e);
+    }
+}
+</script>

--- a/include/gemini.php
+++ b/include/gemini.php
@@ -1,0 +1,22 @@
+<?php
+class GeminiClient {
+    public static function call($prompt) {
+        $key = getenv('GEMINI_API_KEY');
+        if (!$key)
+            return null;
+        $url = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=' . $key;
+        $body = json_encode(array(
+            'contents' => array(array('parts' => array(array('text' => $prompt)))))
+        );
+        $ch = curl_init($url);
+        curl_setopt_array($ch, array(
+            CURLOPT_POST => true,
+            CURLOPT_HTTPHEADER => array('Content-Type: application/json'),
+            CURLOPT_POSTFIELDS => $body,
+            CURLOPT_RETURNTRANSFER => true
+        ));
+        $res = curl_exec($ch);
+        curl_close($ch);
+        return json_decode($res, true);
+    }
+}

--- a/include/plugins/firesync/config.php
+++ b/include/plugins/firesync/config.php
@@ -8,6 +8,13 @@ class FireSyncPluginConfig extends PluginConfig {
                 'label' => 'Firebase Project ID',
                 'required' => true,
             )),
+            'verbose_logging' => new BooleanField(array(
+                'label' => 'Verbose Logging',
+                'default' => false,
+                'configuration' => array(
+                    'desc' => 'Log request and response data for debugging',
+                ),
+            )),
         );
     }
 

--- a/include/plugins/firesync/config.php
+++ b/include/plugins/firesync/config.php
@@ -1,0 +1,17 @@
+<?php
+require_once(INCLUDE_DIR . 'class.plugin.php');
+
+class FireSyncPluginConfig extends PluginConfig {
+    function getOptions() {
+        return array(
+            'project_id' => new TextboxField(array(
+                'label' => 'Firebase Project ID',
+                'required' => true,
+            )),
+        );
+    }
+
+    function pre_save(&$config, &$errors) {
+        return true;
+    }
+}

--- a/include/plugins/firesync/plugin.php
+++ b/include/plugins/firesync/plugin.php
@@ -77,7 +77,17 @@ class FireSyncPlugin extends Plugin {
             CURLOPT_POSTFIELDS => $body,
             CURLOPT_RETURNTRANSFER => true
         ));
-        curl_exec($ch);
+        $result = curl_exec($ch);
+        $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        if ($result === false || $status != 200) {
+            $message = sprintf('FireSyncPlugin: Firestore post failed (status %s)', $status);
+            if ($result === false)
+                $message .= ' ' . curl_error($ch);
+            if ($this->getConfig()->get('verbose_logging')) {
+                $message .= sprintf(' Request: %s Response: %s', $body, var_export($result, true));
+            }
+            error_log($message);
+        }
         curl_close($ch);
     }
 

--- a/include/plugins/firesync/plugin.php
+++ b/include/plugins/firesync/plugin.php
@@ -1,0 +1,90 @@
+<?php
+require_once(INCLUDE_DIR . 'class.plugin.php');
+
+class FireSyncPlugin extends Plugin {
+    var $config_class = 'FireSyncPluginConfig';
+
+    function bootstrap() {
+        Signal::connect('ticket.created', array($this, 'onTicketEvent'));
+        Signal::connect('threadentry.created', array($this, 'onThreadEntry'));
+        Signal::connect('ticket.assigned', array($this, 'onTicketAssigned'));
+        Signal::connect('ticket.status', array($this, 'onTicketStatus'));
+    }
+
+    function onTicketEvent(Ticket $ticket) {
+        $payload = array(
+            'ticket_id' => $ticket->getId(),
+            'status'    => $ticket->getStatus(),
+            'created'   => $ticket->getCreateDate(),
+        );
+        $this->postToFirestore('tickets', $payload);
+    }
+
+    function onThreadEntry(ThreadEntry $entry) {
+        if ($entry->getThread()->getObjectType() != 'T')
+            return;
+        $payload = array(
+            'ticket_id' => $entry->getThreadId(),
+            'poster'    => $entry->getPoster(),
+            'message'   => $entry->getBody(),
+            'created'   => $entry->getCreateDate(),
+        );
+        $this->postToFirestore('tickets_comments', $payload);
+    }
+
+    function onTicketAssigned($ticket, $assignee) {
+        if (!$ticket instanceof Ticket)
+            return;
+        $name = (is_object($assignee) && method_exists($assignee, 'getName')) ?
+            $assignee->getName() : '';
+        $payload = array(
+            'ticket_id' => $ticket->getId(),
+            'type'      => 'assigned',
+            'agent'     => $name,
+            'created'   => time(),
+        );
+        $this->postToFirestore('user_notifications', $payload);
+    }
+
+    function onTicketStatus($ticket, $status) {
+        if (!$ticket instanceof Ticket)
+            return;
+        $payload = array(
+            'ticket_id' => $ticket->getId(),
+            'type'      => 'status',
+            'status'    => (string)$status,
+            'created'   => time(),
+        );
+        $this->postToFirestore('user_notifications', $payload);
+    }
+
+    private function postToFirestore($collection, array $payload) {
+        $project = $this->getConfig()->get('project_id');
+        $token = getenv('FIREBASE_TOKEN');
+        if (!$project || !$token)
+            return;
+
+        $url = sprintf('https://firestore.googleapis.com/v1/projects/%s/databases/(default)/documents/%s',
+            $project, $collection);
+        $body = json_encode(array('fields' => $this->buildFields($payload)));
+        $ch = curl_init($url);
+        curl_setopt_array($ch, array(
+            CURLOPT_POST => true,
+            CURLOPT_HTTPHEADER => array(
+                'Authorization: Bearer ' . $token,
+                'Content-Type: application/json'
+            ),
+            CURLOPT_POSTFIELDS => $body,
+            CURLOPT_RETURNTRANSFER => true
+        ));
+        curl_exec($ch);
+        curl_close($ch);
+    }
+
+    private function buildFields(array $data) {
+        $fields = array();
+        foreach ($data as $k => $v)
+            $fields[$k] = array('stringValue' => (string)$v);
+        return $fields;
+    }
+}

--- a/include/staff/faq.inc.php
+++ b/include/staff/faq.inc.php
@@ -190,7 +190,28 @@ if ($faq && count($langs) > 1) { ?>
 list($draft, $attrs) = Draft::getDraftAndDataAttrs('faq', $namespace, $answer);
 echo $attrs; ?>><?php echo $draft ?: Format::viewableImages($answer);
         ?></textarea>
-
+    </div>
+<?php if ($tag == $cfg->getPrimaryLanguage()) { ?>
+    <div style="margin-top:5px;">
+        <input type="button" id="geminiDraft" value="<?php echo __('Generate Draft'); ?>">
+    </div>
+    <script type="text/javascript">
+    document.getElementById('geminiDraft').addEventListener('click', async function() {
+        const topic = document.querySelector('input[name="question"]').value;
+        const content = document.querySelector('textarea[name="answer"]').value;
+        try {
+            const res = await fetch('../api/gemini.php', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({action: 'kb', topic: topic, content: content})
+            });
+            const data = await res.json();
+            if (data.article)
+                document.querySelector('textarea[name="answer"]').value = data.article;
+        } catch (e) { console.log(e); }
+    });
+    </script>
+<?php } ?>
     </div>
     </div>
 <?php } ?>


### PR DESCRIPTION
## Summary
- extend FireSync plugin to push ticket assignment and status change events into Firestore notifications
- add knowledge-base draft generation to Gemini API and expose a button in the FAQ editor
- adjust ticket form Gemini request to specify triage action

## Testing
- `php -l include/plugins/firesync/plugin.php`
- `php -l api/gemini.php`
- `php -l include/client/open.inc.php`
- `php -l include/staff/faq.inc.php`


------
https://chatgpt.com/codex/tasks/task_e_689cafa938c48323bd0ff5319fc77541