### PR TITLE
Improve FireSync error handling and logging

### DIFF
--- a/include/plugins/firesync/config.php
+++ b/include/plugins/firesync/config.php
@@ -8,6 +8,13 @@ class FireSyncPluginConfig extends PluginConfig {
                 'label' => 'Firebase Project ID',
                 'required' => true,
             )),
+            'verbose_logging' => new BooleanField(array(
+                'label' => 'Verbose Logging',
+                'default' => false,
+                'configuration' => array(
+                    'desc' => 'Log request and response data for debugging',
+                ),
+            )),
         );
     }
 

--- a/include/plugins/firesync/plugin.php
+++ b/include/plugins/firesync/plugin.php
@@ -49,7 +49,18 @@ class FireSyncPlugin extends Plugin {
             CURLOPT_POSTFIELDS => $body,
             CURLOPT_RETURNTRANSFER => true
         ));
-        curl_exec($ch);
+
+        $result = curl_exec($ch);
+        $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        if ($result === false || $status != 200) {
+            $message = sprintf('FireSyncPlugin: Firestore post failed (status %s)', $status);
+            if ($result === false)
+                $message .= ' ' . curl_error($ch);
+            if ($this->getConfig()->get('verbose_logging')) {
+                $message .= sprintf(' Request: %s Response: %s', $body, var_export($result, true));
+            }
+            error_log($message);
+        }
         curl_close($ch);
     }
 


### PR DESCRIPTION
## Summary
- Capture Firestore API responses in FireSync plugin
- Log request failures and optionally log verbose details
- Add plugin setting to enable verbose logging

## Testing
- `php -l include/plugins/firesync/plugin.php`
- `php -l include/plugins/firesync/config.php`


------
https://chatgpt.com/codex/tasks/task_e_689cf3197c9c83239449f502420bca82