### PR TITLE
Gracefully handle invalid Gemini responses

### DIFF
--- a/api/gemini.php
+++ b/api/gemini.php
@@ -17,6 +17,14 @@ $prompt  = "You are a ticket triage assistant. Choose the best category and prio
            "Subject: $subject\nBody: $body";
 
 $response = GeminiClient::call($prompt);
+if ($response === false || !is_array($response) || empty($response['candidates'])) {
+    error_log('Gemini API error: ' . json_encode($response));
+    http_response_code(502);
+    header('Content-Type: application/json');
+    echo json_encode(array('category' => '', 'priority' => ''));
+    exit;
+}
+
 $choice = $response['candidates'][0]['content']['parts'][0]['text'] ?? '';
 $result = json_decode($choice, true);
 if (!is_array($result))


### PR DESCRIPTION
## Summary
- Handle missing Gemini API response candidates and return a 502 with an empty JSON skeleton
- Log Gemini API errors for easier debugging

## Testing
- `php -l api/gemini.php`


------
https://chatgpt.com/codex/tasks/task_e_689cf317f33c832397120b18626b9283