### PR TITLE
Include triage action in ticket field suggestions

### DIFF
--- a/include/client/open.inc.php
+++ b/include/client/open.inc.php
@@ -135,7 +135,7 @@ async function suggestFields() {
         const res = await fetch('api/gemini.php', {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({subject: subject, body: body})
+            body: JSON.stringify({action: 'triage', subject: subject, body: body})
         });
         const data = await res.json();
         if (data.category) {


### PR DESCRIPTION
## Summary
- include triage action in ticket field suggestion request
- ensure no leftover fetch code or conflict markers remain

## Testing
- `php -l include/client/open.inc.php`
- `rg '<<<<<<<|=======|>>>>>>>' -n include/client/open.inc.php`
- `rg 'fetch' -n include/client/open.inc.php`


------
https://chatgpt.com/codex/tasks/task_e_689cf3163c1483239bdc5b42ac532d85