### PR TITLE
Enhance Gemini API with action routing

### DIFF
--- a/api/gemini.php
+++ b/api/gemini.php
@@ -7,20 +7,38 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 }
 
 $data = json_decode(file_get_contents('php://input'), true);
-$subject = $data['subject'] ?? '';
-$body    = $data['body'] ?? '';
-$prompt  = "You are a ticket triage assistant. Choose the best category and priority from the lists.\n".
-           "Categories: Incident: Software > VPN, Software > Email, Hardware > Printer, Hardware > Laptop, Network > Connectivity; " .
-           "Service Request: Software > Licensing, Hardware > New Employee, Access > Shared Drive, Access > New Account, Hardware > Peripheral Request.\n".
-           "Priorities: Low, Medium, High, Urgent.\n".
-           "Respond in JSON with keys category and priority.\n".
-           "Subject: $subject\nBody: $body";
+$action = $data['action'] ?? '';
 
-$response = GeminiClient::call($prompt);
-$choice = $response['candidates'][0]['content']['parts'][0]['text'] ?? '';
-$result = json_decode($choice, true);
-if (!is_array($result))
-    $result = array('category' => '', 'priority' => '');
+switch ($action) {
+case 'triage':
+    $subject = $data['subject'] ?? '';
+    $body    = $data['body'] ?? '';
+    $prompt  = "You are a ticket triage assistant. Choose the best category and priority from the lists.\n"
+        . "Categories: Incident: Software > VPN, Software > Email, Hardware > Printer, Hardware > Laptop, Network > Connectivity; "
+        . "Service Request: Software > Licensing, Hardware > New Employee, Access > Shared Drive, Access > New Account, Hardware > Peripheral Request.\n"
+        . "Priorities: Low, Medium, High, Urgent.\n"
+        . "Respond in JSON with keys category and priority.\n"
+        . "Subject: $subject\nBody: $body";
+    $response = GeminiClient::call($prompt);
+    $choice = $response['candidates'][0]['content']['parts'][0]['text'] ?? '';
+    $result = json_decode($choice, true);
+    if (!is_array($result))
+        $result = array('category' => '', 'priority' => '');
+    break;
+
+case 'kb':
+    $question = $data['question'] ?? '';
+    $prompt = "You are a knowledge base assistant. Answer the user's question based on available information.\n"
+        . "Question: $question";
+    $response = GeminiClient::call($prompt);
+    $answer = $response['candidates'][0]['content']['parts'][0]['text'] ?? '';
+    $result = array('answer' => $answer);
+    break;
+
+default:
+    http_response_code(400);
+    $result = array('error' => 'Unknown action');
+}
 
 header('Content-Type: application/json');
 echo json_encode($result);


### PR DESCRIPTION
## Summary
- Parse `action` parameter in `api/gemini.php`
- Support `triage` and `kb` actions returning JSON responses

## Testing
- `php -l api/gemini.php`


------
https://chatgpt.com/codex/tasks/task_e_689cf31538ec83238d842fb43435cff9