### PR TITLE
Improve FireSync error handling and logging

### DIFF
--- a/api/gemini.php
+++ b/api/gemini.php
@@ -6,21 +6,51 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     exit;
 }
 
-$data = json_decode(file_get_contents('php://input'), true);
-$subject = $data['subject'] ?? '';
-$body    = $data['body'] ?? '';
-$prompt  = "You are a ticket triage assistant. Choose the best category and priority from the lists.\n".
-           "Categories: Incident: Software > VPN, Software > Email, Hardware > Printer, Hardware > Laptop, Network > Connectivity; " .
-           "Service Request: Software > Licensing, Hardware > New Employee, Access > Shared Drive, Access > New Account, Hardware > Peripheral Request.\n".
-           "Priorities: Low, Medium, High, Urgent.\n".
-           "Respond in JSON with keys category and priority.\n".
-           "Subject: $subject\nBody: $body";
+$data   = json_decode(file_get_contents('php://input'), true);
+$action = $data['action'] ?? '';
 
-$response = GeminiClient::call($prompt);
-$choice = $response['candidates'][0]['content']['parts'][0]['text'] ?? '';
-$result = json_decode($choice, true);
-if (!is_array($result))
-    $result = array('category' => '', 'priority' => '');
+switch ($action) {
+case 'triage':
+    $subject = $data['subject'] ?? '';
+    $body    = $data['body'] ?? '';
+    $prompt  = "You are a ticket triage assistant. Choose the best category and priority from the lists.\n"
+        . "Categories: Incident: Software > VPN, Software > Email, Hardware > Printer, Hardware > Laptop, Network > Connectivity; "
+        . "Service Request: Software > Licensing, Hardware > New Employee, Access > Shared Drive, Access > New Account, Hardware > Peripheral Request.\n"
+        . "Priorities: Low, Medium, High, Urgent.\n"
+        . "Respond in JSON with keys category and priority.\n"
+        . "Subject: $subject\nBody: $body";
+    $response = GeminiClient::call($prompt);
+    if ($response === false || !is_array($response) || empty($response['candidates'])) {
+        error_log('Gemini API error: ' . json_encode($response));
+        http_response_code(502);
+        $result = array('category' => '', 'priority' => '');
+        break;
+    }
+    $choice = $response['candidates'][0]['content']['parts'][0]['text'] ?? '';
+    $result = json_decode($choice, true);
+    if (!is_array($result))
+        $result = array('category' => '', 'priority' => '');
+    break;
+
+case 'kb':
+    $question = $data['question'] ?? '';
+    $prompt = "You are a knowledge base assistant. Answer the user's question based on available information.\n"
+        . "Question: $question";
+    $response = GeminiClient::call($prompt);
+    if ($response === false || !is_array($response) || empty($response['candidates'])) {
+        error_log('Gemini API error: ' . json_encode($response));
+        http_response_code(502);
+        $result = array('answer' => '');
+        break;
+    }
+    $answer = $response['candidates'][0]['content']['parts'][0]['text'] ?? '';
+    $result = array('answer' => $answer);
+    break;
+
+default:
+    http_response_code(400);
+    $result = array('error' => 'Unknown action');
+}
 
 header('Content-Type: application/json');
 echo json_encode($result);

--- a/include/plugins/firesync/config.php
+++ b/include/plugins/firesync/config.php
@@ -8,6 +8,13 @@ class FireSyncPluginConfig extends PluginConfig {
                 'label' => 'Firebase Project ID',
                 'required' => true,
             )),
+            'verbose_logging' => new BooleanField(array(
+                'label' => 'Verbose Logging',
+                'default' => false,
+                'configuration' => array(
+                    'desc' => 'Log request and response data for debugging',
+                ),
+            )),
         );
     }
 

--- a/include/plugins/firesync/plugin.php
+++ b/include/plugins/firesync/plugin.php
@@ -49,7 +49,18 @@ class FireSyncPlugin extends Plugin {
             CURLOPT_POSTFIELDS => $body,
             CURLOPT_RETURNTRANSFER => true
         ));
-        curl_exec($ch);
+
+        $result = curl_exec($ch);
+        $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        if ($result === false || $status != 200) {
+            $message = sprintf('FireSyncPlugin: Firestore post failed (status %s)', $status);
+            if ($result === false)
+                $message .= ' ' . curl_error($ch);
+            if ($this->getConfig()->get('verbose_logging')) {
+                $message .= sprintf(' Request: %s Response: %s', $body, var_export($result, true));
+            }
+            error_log($message);
+        }
         curl_close($ch);
     }
 


### PR DESCRIPTION
## Summary
- Capture Firestore API responses in FireSync plugin
- Log request failures and optionally log verbose details
- Add plugin setting to enable verbose logging
- Resolve merge markers in Gemini API and handle triage and KB actions with error checks

## Testing
- `php -l include/plugins/firesync/plugin.php`
- `php -l include/plugins/firesync/config.php`
- `php -l api/gemini.php`


------
https://chatgpt.com/codex/tasks/task_e_689cf3197c9c83239449f502420bca82